### PR TITLE
Add hotfixes restapi service

### DIFF
--- a/src/plone/app/vulnerabilities/browser/hotfix_list.pt
+++ b/src/plone/app/vulnerabilities/browser/hotfix_list.pt
@@ -62,8 +62,8 @@
       </header>
       <ul class="portletContent">
         <li class="portletItem"
-            tal:repeat="hotfix view/get_hotfixes">
-          <a href="" tal:attributes="href hotfix/getURL" tal:content="hotfix/id">Hotfix</a>
+            tal:repeat="hotfix view/hotfixes">
+          <a href="" tal:attributes="href hotfix/absolute_url" tal:content="hotfix/id">Hotfix</a>
         </li>
       </ul>
       <footer class="portletFooter">

--- a/src/plone/app/vulnerabilities/browser/hotfix_list.pt
+++ b/src/plone/app/vulnerabilities/browser/hotfix_list.pt
@@ -45,7 +45,7 @@
             <td tal:content="python: 'Yes' if version['maintenance'] else 'No'"  tal:attributes="class python: 'good' if version['maintenance'] else 'bad'"></td>
             <td>
               <tal:hotfixes tal:repeat="hotfix hotfixes">
-                <a href="" tal:attributes="href hotfix/getURL" tal:content="hotfix/id">Hotfix</a> <br/>
+                <a href="${hotfix/absolute_url}">${hotfix/getId}</a> <br/>
               </tal:hotfixes>
             </td>
           </tr>

--- a/src/plone/app/vulnerabilities/browser/hotfix_list.pt
+++ b/src/plone/app/vulnerabilities/browser/hotfix_list.pt
@@ -36,16 +36,16 @@
           <th>Active Maintenance</th>
           <th>Hotfix</th>
         </thead>
-        <tal:versions repeat="version view/get_versions">
-          <tr class="" tal:define="hotfixes python: view.get_hotfixes_for_version(version['name'])"
+        <tal:versions repeat="version view/get_combined_info">
+          <tr class=""
               tal:attributes="class python:'non_supported_version' if not version['security'] and not version['maintenance'] else 'supported_version'">
             <td tal:content="version/name"></td>
             <td tal:content="version/date"></td>
             <td tal:content="python: 'Yes' if version['security'] else 'No'" tal:attributes="class python: 'good' if version['security'] else 'bad'"></td>
             <td tal:content="python: 'Yes' if version['maintenance'] else 'No'"  tal:attributes="class python: 'good' if version['maintenance'] else 'bad'"></td>
             <td>
-              <tal:hotfixes tal:repeat="hotfix hotfixes">
-                <a href="${hotfix/absolute_url}">${hotfix/getId}</a> <br/>
+              <tal:hotfixes tal:repeat="hotfix version/hotfixes">
+                <a href="${hotfix/url}">${hotfix/name}</a> <br/>
               </tal:hotfixes>
             </td>
           </tr>

--- a/src/plone/app/vulnerabilities/browser/hotfixes.py
+++ b/src/plone/app/vulnerabilities/browser/hotfixes.py
@@ -1,5 +1,6 @@
 from Acquisition import aq_inner
 from Products.Five.browser import BrowserView
+from copy import deepcopy
 from datetime import datetime
 from plone.app.vulnerabilities.content.hotfix import IHotfix
 from plone.registry.interfaces import IRegistry
@@ -94,14 +95,9 @@ class HostfixListing(BrowserView):
             applied_hotfixes = []
             for fix in self.all_hotfixes_info:
                 if version in fix["affected_versions"]:
-                    # To keep the returned info exactly the same as before,
-                    # we could remove the affected_versions from a copy
-                    # and add this copy.
-                    # from copy import deepcopy
-                    # copied = deepcopy(fix)
-                    # del copied["affected_versions"]
-                    # applied_hotfixes.append(copied)
-                    applied_hotfixes.append(fix)
+                    copied = deepcopy(fix)
+                    del copied["affected_versions"]
+                    applied_hotfixes.append(copied)
             vdata['hotfixes'] = applied_hotfixes
             result.append(vdata)
         return result

--- a/src/plone/app/vulnerabilities/browser/hotfixes.py
+++ b/src/plone/app/vulnerabilities/browser/hotfixes.py
@@ -72,12 +72,6 @@ class HostfixListing(BrowserView):
                 'release_date': fix.release_date.isoformat(),
                 'affected_versions': fix.getAffectedVersions(),
             }
-            if fix.hotfix is not None:
-                fix_data['download_url'] = fix.absolute_url() + \
-                    '/@@download/hotfix'
-                fix_data['md5'] = fix.hotfix.md5
-                fix_data['sha1'] = fix.hotfix.sha1
-                fix_data['pypi_name'] = 'Products.PloneHotfix' + fix.id
             result.append(fix_data)
 
         return result

--- a/src/plone/app/vulnerabilities/configure.zcml
+++ b/src/plone/app/vulnerabilities/configure.zcml
@@ -9,6 +9,7 @@
   <include package="plone.app.dexterity" />
 
   <include package=".browser" />
+  <include package=".services" />
 
   <gs:registerProfile
       name="default"

--- a/src/plone/app/vulnerabilities/services/configure.zcml
+++ b/src/plone/app/vulnerabilities/services/configure.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:cache="http://namespaces.zope.org/cache"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    >
+
+  <plone:service
+      method="GET"
+      factory=".hotfixes.HotfixesGet"
+      for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+      permission="zope2.View"
+      name="@hotfixes"
+      />
+
+</configure>

--- a/src/plone/app/vulnerabilities/services/hotfixes.py
+++ b/src/plone/app/vulnerabilities/services/hotfixes.py
@@ -1,0 +1,16 @@
+from plone.restapi.services import Service
+from zope.component import getMultiAdapter
+
+
+class HotfixesGet(Service):
+    """Get a list of Plone versions with their applicable hotfixes."""
+
+    def reply(self):
+        # Reuse the hotfix_json view.
+        serializer = getMultiAdapter((self.context, self.request), name="hotfix_json")
+
+        if serializer is None:
+            self.request.response.setStatus(501)
+            return dict(error=dict(message="No serializer available."))
+
+        return serializer.get_combined_info()


### PR DESCRIPTION
This is the backend part of https://github.com/plone/plone.org/issues/43

The first seven commits make the original code much faster. On current plone.org at https://plone.org/security/hotfixes/ loading the page takes ten seconds. Locally it was about 3.5 seconds. With these improvements, it is down to about 300 milliseconds, so at least ten times as fast.

The last two commits add a restapi service at `@hotfixes`. This is only registered for the Plone Site root. The service is only a small wrapper around the existing backend view `@@hotfix_json`. If anyone used this view, they should start using the new service now.

You can call the service with `?version=5.2.10` to get only information for this specific Plone version. Theoretically this could be used by an add-on to show a message when the current Plone version needs a hotfix.

Anyway, I hope someone is willing to write a Volto view to call the `@hotfixes` endpoint for the new plone.org.