### PR TITLE
Dont import zope.interface.implements

### DIFF
--- a/src/plone/app/vulnerabilities/versions.py
+++ b/src/plone/app/vulnerabilities/versions.py
@@ -1,4 +1,3 @@
-from zope.interface import implements
 from zope.schema.vocabulary import SimpleTerm, SimpleVocabulary
 from zope.component import getUtility
 from plone.registry.interfaces import IRegistry


### PR DESCRIPTION
Seems like `implements` was deprecated in v4.0.0 and removed completely in 6.0: see https://github.com/zopefoundation/zope.interface/blob/master/CHANGES.rst#60-2023-03-17

It also doesn't seem to be used in versions.py and causes an import error when using uwsgi instead of waitress.